### PR TITLE
Lock api client version to 0.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^5.5 || ^7.0",
         "symfony/framework-bundle": "^2.7 || ^3.0",
         "guzzlehttp/guzzle": "^5.0 || ^6.0",
-        "movingimage/vmpro-api-client": "dev-master"
+        "movingimage/vmpro-api-client": "0.7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.12",


### PR DESCRIPTION
Since this bundle is only a thin wrapper around the client and is there only to provide simple integration of the client into the symfony projects, I propose we lock the client to the specific version and also to keep the versions of these two libraries in sync (so both client and bundle will now have version 0.7.0).