### PR TITLE
Adds support for bypassing cache by providing a pre-defined request argument

### DIFF
--- a/Decorator/BlackholeCacheItemDecorator.php
+++ b/Decorator/BlackholeCacheItemDecorator.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace MovingImage\Bundle\VMProApiBundle\Decorator;
+
+use Psr\Cache\CacheItemInterface;
+
+/**
+ * Decorator that wraps around any CacheItemInterface implementation
+ * and overrides the `isHit` method by always returning false.
+ * Therefore, this is a CacheItem implementation useful for forcing cache to be refreshed.
+ */
+class BlackholeCacheItemDecorator implements CacheItemInterface
+{
+    /**
+     * Decorated CacheItem implementation.
+     *
+     * @var CacheItemInterface
+     */
+    private $cacheItem;
+
+    /**
+     * @param CacheItemInterface $cacheItem
+     */
+    public function __construct(CacheItemInterface $cacheItem)
+    {
+        $this->cacheItem = $cacheItem;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getKey()
+    {
+        return $this->cacheItem->getKey();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get()
+    {
+        return $this->cacheItem->get();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isHit()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($value)
+    {
+        return $this->cacheItem->set($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function expiresAt($expiration)
+    {
+        return $this->cacheItem->expiresAt($expiration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function expiresAfter($time)
+    {
+        return $this->cacheItem->expiresAfter($time);
+    }
+
+    /**
+     * Returns the decorated CacheItemInterface implementation.
+     *
+     * @return CacheItemInterface
+     */
+    public function getDecoratedItem()
+    {
+        return $this->cacheItem;
+    }
+}

--- a/Decorator/BlackholeCacheItemPoolDecorator.php
+++ b/Decorator/BlackholeCacheItemPoolDecorator.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace MovingImage\Bundle\VMProApiBundle\Decorator;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Decorator that wraps around any CacheItemPoolInterface implementation
+ * and overrides the `isHit` method by always returning false.
+ * Therefore, this is a CacheItemPool implementation useful for forcing cache to be refreshed.
+ */
+class BlackholeCacheItemPoolDecorator implements CacheItemPoolInterface
+{
+    /**
+     * Decorated CacheItemPool implementation.
+     *
+     * @var CacheItemPoolInterface
+     */
+    private $cacheItemPool;
+
+    /**
+     * @param CacheItemPoolInterface $cacheItemPool
+     */
+    public function __construct(CacheItemPoolInterface $cacheItemPool)
+    {
+        $this->cacheItemPool = $cacheItemPool;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key)
+    {
+        return new BlackholeCacheItemDecorator($this->cacheItemPool->getItem($key));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(array $keys = array())
+    {
+        $items = [];
+        foreach ($this->cacheItemPool->getItems($keys) as $item) {
+            $items[] = new BlackholeCacheItemDecorator($item);
+        }
+
+        return $items;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasItem($key)
+    {
+        return $this->cacheItemPool->hasItem($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        return $this->cacheItemPool->clear();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItem($key)
+    {
+        return $this->cacheItemPool->deleteItem($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys)
+    {
+        return $this->cacheItemPool->deleteItems($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(CacheItemInterface $item)
+    {
+        if ($item instanceof BlackholeCacheItemDecorator) {
+            $item = $item->getDecoratedItem();
+        }
+
+        return $this->cacheItemPool->save($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        if ($item instanceof BlackholeCacheItemDecorator) {
+            $item = $item->getDecoratedItem();
+        }
+
+        return $this->cacheItemPool->saveDeferred($item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        return $this->cacheItemPool->commit();
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,6 +57,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('cache_ttl')
                     ->defaultValue(null)
                 ->end()
+                ->scalarNode('cache_bypass_argument')
+                    ->defaultValue(null)
+                ->end()
             ->end()
         ;
 

--- a/EventListener/BypassCacheListener.php
+++ b/EventListener/BypassCacheListener.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace MovingImage\Bundle\VMProApiBundle\EventListener;
+
+use MovingImage\Bundle\VMProApiBundle\Decorator\BlackholeCacheItemPoolDecorator;
+use MovingImage\Client\VMPro\ApiClient\AbstractApiClient;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * This listener kicks in only if the `cache_bypass_argument` bundle config option is set.
+ * If the request contains an argument matching the value configured in the aforementioned config option
+ * and the value of that argument evaluates to true, this listener will modify the cache pool implementation
+ * used by the VMPro API client, by decorating it with a blackhole cache implementation:
+ * one that stores responses to cache, but never returns a hit.
+ */
+class BypassCacheListener implements EventSubscriberInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var string|null
+     */
+    private $cacheBypassArgument;
+
+    /**
+     * @param ContainerInterface $container
+     * @param string             $cacheBypassArgument
+     */
+    public function __construct(ContainerInterface $container, $cacheBypassArgument = null)
+    {
+        $this->container = $container;
+        $this->cacheBypassArgument = $cacheBypassArgument;
+    }
+
+    /**
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$this->cacheBypassArgument) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if ($request->get($this->cacheBypassArgument)) {
+            /** @var AbstractApiClient $apiClient */
+            $apiClient = $this->container->get('vmpro_api.client');
+            $cachePool = new BlackholeCacheItemPoolDecorator($apiClient->getCacheItemPool());
+            $apiClient->setCacheItemPool($cachePool);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest',
+        ];
+    }
+}

--- a/Resources/config/services/main.yml
+++ b/Resources/config/services/main.yml
@@ -29,7 +29,7 @@ services:
     vmpro_api.bypass_cache_listener:
         class: MovingImage\Bundle\VMProApiBundle\EventListener\BypassCacheListener
         arguments:
-            - '@service_container'
+            - '@vmpro_api.client'
             - '%vm_pro_api_cache_bypass_argument%'
         tags:
             - { name: kernel.event_subscriber }

--- a/Resources/config/services/main.yml
+++ b/Resources/config/services/main.yml
@@ -23,3 +23,13 @@ services:
             - "@vmpro_api.unauthenticated_guzzle_client"
             - "@vmpro_api.credentials"
             - "@vmpro_api.token_extractor"
+
+    # Event listener that will bypass cache for requests that have the pre-defined request argument
+    # The name of this request argument is configured using `cache_bypass_argument` option
+    vmpro_api.bypass_cache_listener:
+        class: MovingImage\Bundle\VMProApiBundle\EventListener\BypassCacheListener
+        arguments:
+            - '@service_container'
+            - '%vm_pro_api_cache_bypass_argument%'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/Tests/Decorator/BlackholeCacheItemPoolDecoratorTest.php
+++ b/Tests/Decorator/BlackholeCacheItemPoolDecoratorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace MovingImage\Bundle\VMProApiBundle\Tests\Decorator;
+
+use MovingImage\Bundle\VMProApiBundle\Decorator\BlackholeCacheItemDecorator;
+use MovingImage\Bundle\VMProApiBundle\Decorator\BlackholeCacheItemPoolDecorator;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class BlackholeCacheItemPoolDecoratorTest extends TestCase
+{
+    /**
+     * Asserts that blackhole pool will always report a cache miss.
+     */
+    public function testIsHit()
+    {
+        $cachePool = $this->getCachePool(['test' => 'test']);
+
+        $blackholePool = new BlackholeCacheItemPoolDecorator($cachePool);
+
+        $this->assertTrue($cachePool->getItem('test')->isHit());
+        $this->assertFalse($blackholePool->getItem('test')->isHit());
+    }
+
+    /**
+     * Asserts that item returned by the blackhole pool is the correct type.
+     */
+    public function testGetItem()
+    {
+        $cachePool = $this->getCachePool(['test' => 'test']);
+        $blackholePool = new BlackholeCacheItemPoolDecorator($cachePool);
+
+        $this->assertInstanceOf(BlackholeCacheItemDecorator::class, $blackholePool->getItem('test'));
+    }
+
+    /**
+     * Asserts that items returned by the blackhole pool are the correct type.
+     */
+    public function testGetItems()
+    {
+        $cachePool = $this->getCachePool(['test1' => 'test1', 'test2' => 'test2']);
+        $blackholePool = new BlackholeCacheItemPoolDecorator($cachePool);
+
+        foreach ($blackholePool->getItems(['test1', 'test2']) as $item) {
+            $this->assertInstanceOf(BlackholeCacheItemDecorator::class, $item);
+        }
+    }
+
+    /**
+     * Asserts that decorated item returned by the blackhole pool is of the correct type.
+     */
+    public function testGetDecoratedItem()
+    {
+        $cachePool = $this->getCachePool(['test' => 'test']);
+        $cacheItem = $cachePool->getItem('test');
+        $blackholePool = new BlackholeCacheItemPoolDecorator($cachePool);
+        $blackholeItem = $blackholePool->getItem('test');
+
+        $this->assertInstanceOf(get_class($cacheItem), $blackholeItem->getDecoratedItem());
+    }
+
+    /**
+     * Returns an implementation of the CacheItemPoolInterface
+     * initialized with the values provided in the array.
+     *
+     * @param array $values
+     *
+     * @return CacheItemPoolInterface
+     */
+    private function getCachePool(array $values)
+    {
+        $cachePool = new ArrayAdapter();
+        foreach ($values as $key => $value) {
+            $cacheItem = $cachePool->getItem($key);
+            $cacheItem->set($value);
+            $cachePool->save($cacheItem);
+        }
+
+        return $cachePool;
+    }
+}

--- a/Tests/EventListener/BypassCacheListenerTest.php
+++ b/Tests/EventListener/BypassCacheListenerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace MovingImage\Bundle\VMProApiBundle\Tests\EventListener;
+
+use GuzzleHttp\ClientInterface;
+use JMS\Serializer\Serializer;
+use MovingImage\Bundle\VMProApiBundle\EventListener\BypassCacheListener;
+use MovingImage\Client\VMPro\ApiClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class BypassCacheListenerTest extends TestCase
+{
+    /**
+     * Tests onKernelRequest method.
+     *
+     * @dataProvider dataProvider
+     *
+     * @param string $bypassCacheArgument
+     * @param array  $query
+     * @param array  $request
+     * @param array  $attributes
+     * @param array  $cookies
+     * @param bool   $isHit
+     */
+    public function testOnKernelRequest(
+        $bypassCacheArgument,
+        array $query,
+        array $request,
+        array $attributes,
+        array $cookies,
+        $isHit
+    ) {
+        $apiClient = $this->getApiClient();
+        $listener = new BypassCacheListener($apiClient, $bypassCacheArgument);
+        $request = new Request($query, $request, $attributes, $cookies);
+        $kernel = $this->createMock(HttpKernel::class);
+
+        $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener->onKernelRequest($event);
+
+        $this->assertIsHit($isHit, $apiClient->getCacheItemPool());
+    }
+
+    /**
+     * Creates an ApiClient instance with mocked dependencies
+     * and ArrayAdapter as cache pool.
+     *
+     * @return ApiClient
+     */
+    private function getApiClient()
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $serializer = $this->createMock(Serializer::class);
+
+        return new ApiClient($client, $serializer, new ArrayAdapter());
+    }
+
+    /**
+     * Asserts that storing an item to the provided pool followed by immediately
+     * fetching it again from the pool will result in the specified "hit" status.
+     * ($isHit = true -> expecting a cache hit; $isHit = false -> expecting a cache miss).
+     *
+     * @param $isHit
+     * @param CacheItemPoolInterface $pool
+     */
+    private function assertIsHit($isHit, CacheItemPoolInterface $pool)
+    {
+        $item = $pool->getItem('test');
+        $item->set('test');
+        $pool->save($item);
+        $this->assertSame($isHit, $pool->getItem('test')->isHit());
+    }
+
+    /**
+     * Data provider for testOnKernelRequest.
+     * Provides various combinations of request arguments and configuration,
+     * as well as the expected behavior.
+     *
+     * @return array
+     */
+    public function dataProvider()
+    {
+        return [
+            [null, [], [], [], [], true],
+            [null, ['bypass_cache' => 1], [], [], [], true],
+            [null, [], ['bypass_cache' => 1], [], [], true],
+            [null, [], [], ['bypass_cache' => 1], [], true],
+            [null, [], [], [], ['bypass_cache' => 1], true],
+
+            ['bypass_cache', ['bypass_cache' => 1], [], [], [], false],
+            ['bypass_cache', [], ['bypass_cache' => 1], [], [], false],
+            ['bypass_cache', [], [], ['bypass_cache' => 1], [], false],
+            ['bypass_cache', [], [], [], ['bypass_cache' => 1], false],
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.12",
-        "phpunit/phpunit": "^4.5 || ^5.0"
+        "phpunit/phpunit": "^4.5 || ^5.0",
+        "symfony/cache": "~3.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": "^5.5 || ^7.0",
         "symfony/framework-bundle": "^2.7 || ^3.0",
         "guzzlehttp/guzzle": "^5.0 || ^6.0",
-        "movingimage/vmpro-api-client": "dev-master"
+        "movingimage/vmpro-api-client": "dev-master",
+        "psr/cache": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.12",


### PR DESCRIPTION
Adds an event listener that switches the API client cache to a "blackhole" implementation if a pre-defined request argument is set. Effectively, this enables reloading cache by providing a request argument (in either GET, POST or COOKIE).