### PR TITLE
Disallow non-alphanumeric characters in the header when adding stopwatch data

### DIFF
--- a/EventListener/StopwatchListener.php
+++ b/EventListener/StopwatchListener.php
@@ -72,6 +72,8 @@ class StopwatchListener implements EventSubscriberInterface
      */
     private function setHeader(Response $response, $stage, $duration)
     {
+        // disallow non-alphanumeric characters in the header
+        $stage = preg_replace('/[^\d\w]/', '', $stage);
         $headerName = 'X-API-RESPONSE-'.strtoupper($stage);
         $response->headers->set($headerName, $duration);
     }


### PR DESCRIPTION
Having illegal characters in header name may result in an error when processing the HTTP response.